### PR TITLE
Fixed building on Windows Machines and Default Schema method

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,12 +20,6 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
-  <repositories>
-    <repository>
-      <id>github-releases</id>
-      <url>http://oss.sonatype.org/content/repositories/github-releases/</url>
-    </repository>
-  </repositories>
 
   <dependencies>
     <dependency>
@@ -67,7 +61,7 @@
         </executions>
       </plugin>
       <plugin>
-        <version>3.0</version>
+        <version>3.2</version>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
@@ -78,7 +72,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-site-plugin</artifactId>
-        <version>3.0</version>
+        <version>3.2</version>
         <configuration>
           <reportPlugins>
             <plugin>
@@ -110,5 +104,19 @@
       </plugin>
     </plugins>
   </build>
+  <repositories>
+		<repository>
+			<id>repo1</id>
+			<name>Maven Repository</name>
+			<url>http://repo1.maven.org/maven2</url>
+		</repository>
+	</repositories>
+  <pluginRepositories>
+		<pluginRepository>
+			<id>org.apache.maven.plugins</id>
+			<name>Maven plugin Repository</name>
+			<url>http://repo1.maven.org/maven2</url>
+		</pluginRepository>
+	</pluginRepositories>
 </project>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.nuodb.liquibase</groupId>
   <artifactId>liquibase-nuodb</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
+  <version>0.0.2-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>liquibase-nuodb</name>

--- a/src/main/java/liquibase/database/ext/NuoDBDatabase.java
+++ b/src/main/java/liquibase/database/ext/NuoDBDatabase.java
@@ -38,7 +38,9 @@ public class NuoDBDatabase extends AbstractDatabase {
     @Override
     public String getDefaultSchemaName() {
         final String defaultSchemaName = super.getDefaultSchemaName();
-        return defaultSchemaName == null ? "USER" : defaultSchemaName;
+        final String schemaName = getSchemaName(getConnection().getURL());
+
+        return defaultSchemaName == null ? schemaName : defaultSchemaName;
     }
 
     @Override


### PR DESCRIPTION
Mr. Buck - pretty straightforward changes here. We pull the maven-site-plugin from maven central and bumped up the version. 

There may be something that we were missing, but we were always getting the default schema back from the plug-in. Using the getSchemaName method fixed that. 